### PR TITLE
Fix for building the api docs within the ci pipeline 

### DIFF
--- a/.github/workflows/ci-docs-testing.yml
+++ b/.github/workflows/ci-docs-testing.yml
@@ -30,6 +30,9 @@ jobs:
         run: | 
           python -m pip install --upgrade pip 
           pip install sphinx sphinx-toolbox piccolo-theme 
+
+      - name: Install alc-ux demo plugin
+        run: python -m pip install . 
           
       - name: Build the documentation 
         run: sphinx-build -b html docs/source/ docs/build/html 

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -30,6 +30,9 @@ jobs:
         run: | 
           python -m pip install --upgrade pip 
           pip install sphinx sphinx-toolbox piccolo-theme 
+      
+      - name: Install alc-ux demo plugin
+        run: python -m pip install . 
           
       - name: Build the documentation 
         run: sphinx-build -b html docs/source/ docs/build/html 


### PR DESCRIPTION
Installs the aiidalab-alc example python package within the documentation CI pipelines such that the documentation builder can correctly parse the docstrings and create the API documentation. 